### PR TITLE
Fix default company logo loading

### DIFF
--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -6,6 +6,7 @@ import { clearFromBack, resetDial } from "../../utils/helpers/dialpad";
 import { toast } from "react-toastify";
 import { useDispatch } from "react-redux";
 import { userModel } from "../../plugins/models";
+import { companyLogo } from "../../assets/images";
 import {
 	updateCompanyLogo,
 	updateUserDetails,
@@ -26,7 +27,7 @@ function Login() {
 	// const companyLogo = localStorage.getItem("cmpLogo");
 	const [loading, isLoading] = useState(false);
 	const [logoLoading, setLogoLoading] = useState(false);
-	const [logo, setLogo] = useState(localStorage.getItem("cmpLogo") || null);
+       const [logo, setLogo] = useState(localStorage.getItem("cmpLogo") || companyLogo);
 	/**
 	 * The function `handlePinChange` updates the pin by appending the provided data if the pin length is
 	 * less than 6.


### PR DESCRIPTION
## Summary
- fix path to default logo in login page

## Testing
- `npm run lint`
- `npm run build` *(fails: Could not resolve ./ShiftClosing.css)*

------
https://chatgpt.com/codex/tasks/task_e_687b9c6b1f0483238bcf9824420a80d9