### PR TITLE
Fix company logo fallback

### DIFF
--- a/src/components/LeftHeader.jsx
+++ b/src/components/LeftHeader.jsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { useSelector } from "react-redux";
+import { companyLogo } from "../assets/images";
+import { getStoredCompanyLogo } from "../utils/helpers";
 // import { selectOrderType } from "../redux/selector/orderSlector";
 
 function LeftHeader() {
@@ -7,7 +9,7 @@ function LeftHeader() {
 	const { customer } = useSelector((state) => state?.customer);
 	const { table, orderType } = useSelector((state) => state?.order);
 
-	const getCompanyLogo = localStorage.getItem("cmpLogo");
+       const getCompanyLogo = getStoredCompanyLogo();
 
 	return (
 		<div className="bg-[#F2EDED] w-full rounded-lg p-2 flex items-center">

--- a/src/pages/kot/Kot.jsx
+++ b/src/pages/kot/Kot.jsx
@@ -7,7 +7,8 @@ import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import Swal from "sweetalert2";
-import { AdlerLogo } from "../../assets/images";
+import { AdlerLogo, companyLogo } from "../../assets/images";
+import { getStoredCompanyLogo } from "../../utils/helpers";
 import { Layout, ListSlider, SlideArrow } from "../../components";
 import { showConfirmModal } from "../../components/ConfirmatinDialog";
 import NumberInputModal from "../../components/PinINoutModal";
@@ -154,7 +155,7 @@ function Kot() {
 
 	const customer = useSelector(selectCustomer);
 	// const getCompanyLogo = useSelector((state) => state?.user?.comapnyLogoApi);
-	const getCompanyLogo = localStorage.getItem("cmpLogo");
+        const getCompanyLogo = getStoredCompanyLogo();
 	// const { , , ,  } = useSelector(
 	// 	(state) => state?.order
 	// );

--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -7,6 +7,7 @@ import { toast } from "react-toastify";
 import { useDispatch } from "react-redux";
 import { userModel } from "../../plugins/models";
 import { companyLogo } from "../../assets/images";
+import { getStoredCompanyLogo } from "../../utils/helpers";
 import {
 	updateCompanyLogo,
 	updateUserDetails,
@@ -27,7 +28,7 @@ function Login() {
 	// const companyLogo = localStorage.getItem("cmpLogo");
 	const [loading, isLoading] = useState(false);
 	const [logoLoading, setLogoLoading] = useState(false);
-       const [logo, setLogo] = useState(localStorage.getItem("cmpLogo") || companyLogo);
+       const [logo, setLogo] = useState(getStoredCompanyLogo());
 	/**
 	 * The function `handlePinChange` updates the pin by appending the provided data if the pin length is
 	 * less than 6.
@@ -125,14 +126,15 @@ function Login() {
 
 				// Handle Logo
 
-				if (logoData?.status === "true") {
-					const logoUrl = `${import.meta.env.VITE_API_BASE_URL}${
-						logoData?.data?.image || ""
-					}`;
-					dispatch(updateCompanyLogo(logoUrl));
-					localStorage.setItem("cmpLogo", logoUrl);
-					setLogo(logoUrl);
-				}
+                                if (logoData?.status === "true" && logoData?.data?.image) {
+                                        const logoUrl = `${import.meta.env.VITE_API_BASE_URL}${logoData.data.image}`;
+                                        dispatch(updateCompanyLogo(logoUrl));
+                                        localStorage.setItem("cmpLogo", logoUrl);
+                                        setLogo(logoUrl);
+                                } else {
+                                        localStorage.removeItem("cmpLogo");
+                                        setLogo(companyLogo);
+                                }
 			})
 			.catch((error) => {
 				toast.error(t("LOGIN.FAILED_TO_LOAD_INITIAL_CONFIG"));

--- a/src/pages/pay/Pay.jsx
+++ b/src/pages/pay/Pay.jsx
@@ -33,7 +33,8 @@ import {
 	selectTotal,
 } from "../../redux/selector/orderSlector";
 import { Layout } from "../../components";
-import { AdlerLogo } from "../../assets/images";
+import { AdlerLogo, companyLogo } from "../../assets/images";
+import { getStoredCompanyLogo } from "../../utils/helpers";
 import { useDispatch, useSelector } from "react-redux";
 import {
 	OrderSummary,
@@ -180,7 +181,7 @@ function Pay() {
 	const customer = useSelector(selectCustomer);
 	const reduxKotDetail = useSelector(selectKotDetails);
 	// const getCompanyLogo = useSelector((state) => state?.user?.comapnyLogoApi);
-	const getCompanyLogo = localStorage.getItem("cmpLogo");
+       const getCompanyLogo = getStoredCompanyLogo();
 	const amtDecimal = config?.amount || 2;
 
 	const [isModalOpen, setIsModalOpen] = useState(false);

--- a/src/pages/runnningKot/RunningKot.jsx
+++ b/src/pages/runnningKot/RunningKot.jsx
@@ -1,5 +1,7 @@
 import { Icon } from "@iconify/react";
 import { useTranslation } from 'react-i18next';
+import { companyLogo } from "../../assets/images";
+import { getStoredCompanyLogo } from "../../utils/helpers";
 import { Empty, Spin, Table } from "antd";
 import React, {
 	useCallback,
@@ -61,7 +63,7 @@ function RunningKot() {
 	const keyboardNotes = useRef();
     const { t } = useTranslation();
 
-	const getCompanyLogo = localStorage.getItem("cmpLogo");
+       const getCompanyLogo = getStoredCompanyLogo();
 	const userDetails = JSON.parse(localStorage.getItem("user"));
 
 	// const config1 = useSelector(selectConfig);

--- a/src/pages/tableTransfer/Tabletransfer.jsx
+++ b/src/pages/tableTransfer/Tabletransfer.jsx
@@ -1,5 +1,7 @@
 import { Icon } from "@iconify/react";
 import React, { use, useEffect, useRef, useState } from "react";
+import { companyLogo } from "../../assets/images";
+import { getStoredCompanyLogo } from "../../utils/helpers";
 import { useNavigate } from "react-router-dom";
 import { SlideArrow } from "../../components";
 import { tableModel } from "../../plugins/models";
@@ -80,7 +82,7 @@ function Tabletransferdemo() {
   const outletDetail = localStorage.getItem("openOutlet");
   const outlet = JSON.parse(outletDetail);
   const date = localStorage.getItem("dateTime");
-  const getCompanyLogo = localStorage.getItem("cmpLogo");
+  const getCompanyLogo = getStoredCompanyLogo();
 
   const [authenticate, isAuthenticate] = useState(false);
 

--- a/src/pages/tableTransfer/TabletransferDemo.jsx
+++ b/src/pages/tableTransfer/TabletransferDemo.jsx
@@ -1,5 +1,7 @@
 import { Icon } from "@iconify/react";
 import React, { use, useEffect, useRef, useState } from "react";
+import { companyLogo } from "../../assets/images";
+import { getStoredCompanyLogo } from "../../utils/helpers";
 import { useNavigate } from "react-router-dom";
 import { SlideArrow } from "../../components";
 import { tableModel } from "../../plugins/models";
@@ -80,7 +82,7 @@ function Tabletransferdemo() {
   const outletDetail = localStorage.getItem("openOutlet");
   const outlet = JSON.parse(outletDetail);
   const date = localStorage.getItem("dateTime");
-  const getCompanyLogo = localStorage.getItem("cmpLogo");
+  const getCompanyLogo = getStoredCompanyLogo();
 
   const [authenticate, isAuthenticate] = useState(false);
 

--- a/src/utils/helpers/index.js
+++ b/src/utils/helpers/index.js
@@ -115,5 +115,17 @@ export const parseDateTime = (
 			`Failed to parse datetime string: "${dateTimeString}" with format "${inputFormat}"`
 		);
 		return { formateDate: null, formateTime: null };
-	}
+        }
 };
+
+// Convenience function to obtain the stored company logo with a fallback
+import { companyLogo } from "../../assets/images";
+
+export const getStoredCompanyLogo = () => {
+        const stored = localStorage.getItem("cmpLogo");
+        if (!stored || stored === "null" || stored === "undefined") {
+                return companyLogo;
+        }
+        return stored;
+};
+


### PR DESCRIPTION
## Summary
- add helper to fetch company logo from localStorage with fallback to bundled image
- update login and other pages to use new helper

## Testing
- `npm run lint` *(fails: 211 errors, 61 warnings)*
- `npm run build` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b9f09ac2083238632a2f9ac8dab4e